### PR TITLE
Add elasticsearch deployment

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "gce/serviceaccounts/samples2"]
 	path = gce/serviceaccounts/samples2
 	url = https://github.com/GoogleCloudPlatform/deploymentmanager-samples.git
+[submodule "charts/elasticsearch/dependencies/helm-charts"]
+	path = charts/elasticsearch/dependencies/helm-charts
+	url = https://github.com/elastic/helm-charts/

--- a/k8s/helm/elasticsearch/helmfile.yaml
+++ b/k8s/helm/elasticsearch/helmfile.yaml
@@ -1,0 +1,6 @@
+releases:
+- name: elasticsearch
+  namespace: default
+  chart: ./../../../charts/elasticsearch/dependencies/helm-charts/elasticsearch/
+  values:
+  - "values.yaml"

--- a/k8s/helm/elasticsearch/minikube/.gitignore
+++ b/k8s/helm/elasticsearch/minikube/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/k8s/helm/elasticsearch/minikube/Makefile
+++ b/k8s/helm/elasticsearch/minikube/Makefile
@@ -1,0 +1,17 @@
+default: test
+
+RELEASE := helm-es-minikube
+TIMEOUT := 1200s
+
+install:
+	helm upgrade --debug --wait --timeout=$(TIMEOUT) --install  --values ../values.yaml --values values.local.yaml $(RELEASE) ../../../../charts/elasticsearch/dependencies/helm-charts/elasticsearch/
+
+test: install
+	helm test $(RELEASE)
+
+purge:
+	helm del $(RELEASE)
+	kubectl delete pvc --all
+
+member:
+	kubectl get pods --namespace=default -l app=elasticsearch-master

--- a/k8s/helm/elasticsearch/minikube/index.js
+++ b/k8s/helm/elasticsearch/minikube/index.js
@@ -1,0 +1,11 @@
+httpProxy = require('http-proxy');
+
+// run the mediawiki docker containers requests through the local machine
+// to reach the kubernetes NodePort
+var proxy = httpProxy.createProxyServer({target:'http://192.168.49.2:30000'});
+
+proxy.on('proxyReq', function(proxyReq, req, res, options) {
+    console.log(req.method + ' ' + req.url);
+});
+
+proxy.listen(8234);

--- a/k8s/helm/elasticsearch/minikube/values.local.yaml
+++ b/k8s/helm/elasticsearch/minikube/values.local.yaml
@@ -1,0 +1,10 @@
+# Permit co-located instances for solitary minikube virtual machines.
+antiAffinity: "soft"
+
+# Request smaller persistent volumes.
+volumeClaimTemplate:
+  accessModes: [ "ReadWriteOnce" ]
+  storageClassName: "standard"
+  resources:
+    requests:
+      storage: 1000M

--- a/k8s/helm/elasticsearch/values.yaml
+++ b/k8s/helm/elasticsearch/values.yaml
@@ -1,0 +1,26 @@
+image: "wikibase/elasticsearch"
+imageTag: "6.5.4-wmde.1"
+imagePullPolicy: Always
+
+service:
+  type: NodePort
+  nodePort: 30000
+
+replicas: 3
+minimumMasterNodes: 2
+
+esJavaOpts: "-Xms512m -Xmx512m"
+
+resources:
+  requests:
+    cpu: "1000m"
+    memory: "2Gi"
+  limits:
+    cpu: "1000m"
+    memory: "2Gi"
+
+volumeClaimTemplate:
+  accessModes: [ "ReadWriteOnce" ]
+  resources:
+    requests:
+      storage: 10Gi


### PR DESCRIPTION
 Add ElasticSearch deployment

- uses the official elasticsearch charts as submodule from the 6.8 branch
- adds some scripts for running it locally